### PR TITLE
tools: Stricter noise limits for Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -60,11 +60,10 @@
   timezone: "Etc/UTC",
   automergeSchedule: "after 1 am and before 7 am",
   schedule: "every weekend",
-  //prConcurrentLimit: 5, // No more than 5 open PRs at a time.
-  prConcurrentLimit: 0, // <-- TEMPORARY!
+  prConcurrentLimit: 5, // No more than 5 open PRs at a time.
   prCreation: "not-pending", // Wait until status checks have completed before raising the PR
   prNotPendingHours: 4, // ...unless the status checks have been running for 4+ hours.
-  //prHourlyLimit: 4, // No more than 4 PRs per hour.
+  prHourlyLimit: 1, // No more than 1 PR per hour.
   stabilityDays: 2 // Wait 2 days from release before updating.
 }
 


### PR DESCRIPTION
Turn back on the concurrent PR limit and match the hourly limit to starcraft-base